### PR TITLE
update to the bq worker schedules

### DIFF
--- a/queries/schedule.py
+++ b/queries/schedule.py
@@ -19,14 +19,13 @@ import google.oauth2.credentials
 from google.oauth2 import service_account
 from google.cloud import bigquery_datatransfer_v1
 import google.protobuf.json_format
-import os
 
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string('table', '', 'Table name for scheduled query output')
 flags.DEFINE_string('query_file', '', 'Query to schedule')
 
-#hard coded for now
+# hard coded for now
 PROJECT_ID = "four-metrics"
 
 def get_bq_client():

--- a/queries/schedule.py
+++ b/queries/schedule.py
@@ -16,6 +16,7 @@
 from absl import app
 from absl import flags
 import google.oauth2.credentials
+from google.oauth2 import service_account
 from google.cloud import bigquery_datatransfer_v1
 import google.protobuf.json_format
 import os
@@ -24,10 +25,9 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string('table', '', 'Table name for scheduled query output')
 flags.DEFINE_string('query_file', '', 'Query to schedule')
-flags.DEFINE_string('access_token', '', 'Access token from `gcloud auth print-access-token`')
 
-PROJECT_ID = os.environ.get("FOURKEYS_PROJECT")
-
+#hard coded for now
+PROJECT_ID = "four-metrics"
 
 def get_bq_client():
     # If the BigQuery DataTransfer API has been enabled recently, there is sometimes a delay.
@@ -35,8 +35,8 @@ def get_bq_client():
     retry = True
     while retry is True:
         try:
-            # Set up the client
-            credentials = google.oauth2.credentials.Credentials(FLAGS.access_token)
+            # Set up the credentials from a file
+            credentials = service_account.Credentials.from_service_account_file('/users/gripp/repos/fourkeys/queries/token.json')
             client = bigquery_datatransfer_v1.DataTransferServiceClient(credentials=credentials)
             parent = client.project_path(PROJECT_ID)
             retry = False

--- a/setup/bq_update.sh
+++ b/setup/bq_update.sh
@@ -29,6 +29,7 @@
 
 
 schedule_bq_queries(){
+  export PARENT_PROJECT=$(gcloud config get-value project)
   echo "Check BigQueryDataTransfer is enabled" 
   enabled=$(gcloud services list --enabled --filter name:bigquerydatatransfer.googleapis.com)
 
@@ -39,14 +40,16 @@ schedule_bq_queries(){
   done
 
   cd ../queries/
-  pip3 install -r requirements.txt -q --user
+  # grpcio fails on local ok in cloud shell using these extra commands help with the install
+  pip3 install --no-cache-dir --force-reinstall -Iv -r requirements.txt -q
   token=$(gcloud auth print-access-token)
 
   echo "Creating BigQuery scheduled queries for derived tables.."; set -x
 
-  python3 schedule.py --query_file=changes.sql --table=changes --access_token=${token}
-  python3 schedule.py --query_file=deployments.sql --table=deployments  --access_token=${token}
-  python3 schedule.py --query_file=incidents.sql --table=incidents --access_token=${token}
+    #refactored how auth is used nolonger need the auth token
+    python3 schedule.py --query_file=changes.sql --table=changes
+    python3 schedule.py --query_file=deployments.sql --table=deployments
+    python3 schedule.py --query_file=incidents.sql --table=incidents
 
   set +x; echo
   cd ${DIR}


### PR DESCRIPTION
changed how the pip install commands are used need to update all shell scripts that call the pip install
changed how auth done this mech uses same setup however user required to download the creds from gcloud dashboard
the original method around auth was failing and unable to resolve this new approach seems to be working and feels simpler